### PR TITLE
Fix empty response causing JSON parse exception.

### DIFF
--- a/bigip.go
+++ b/bigip.go
@@ -77,6 +77,10 @@ func (b *BigIP) APICall(options *APIRequest) ([]byte, error) {
 // checkError handles any errors we get from our API requests. It returns either the
 // message of the error, if any, or nil.
 func (b *BigIP) checkError(resp []byte) error {
+	if len(resp) == 0 {
+		return nil
+	}
+
 	var reqError RequestError
 
 	err := json.Unmarshal(resp, &reqError)


### PR DESCRIPTION
Successful DELETE operations return an empty response. This caused a JSON parse exception in checkError.