### PR TITLE
Hide boolean idiosyncrasies 

### DIFF
--- a/bigip.go
+++ b/bigip.go
@@ -35,7 +35,7 @@ type RequestError struct {
 	ErrorStack []string `json:"errorStack,omitempty"`
 }
 
-// NewServer sets up our connection to the BIG-IP system.
+// NewSession sets up our connection to the BIG-IP system.
 func NewSession(host, user, passwd string) *BigIP {
 	return &BigIP{
 		Host:     host,

--- a/net.go
+++ b/net.go
@@ -661,7 +661,7 @@ func (b *BigIP) DeleteRouteDomain(name string) error {
 	return b.checkError(resp)
 }
 
-// ModifyRoute allows you to change any attribute of a route domain. Fields that
+// ModifyRouteDomain allows you to change any attribute of a route domain. Fields that
 // can be modified are referenced in the RouteDomain struct.
 func (b *BigIP) ModifyRouteDomain(name string, config *RouteDomain) error {
 	marshalJSON, err := json.Marshal(config)


### PR DESCRIPTION
the iControlREST API doesn't mask the data types coming out of the tmsh. As such boolean fields are represented a bunch of different ways: yes/no, enabled/disabled, true/false. This is inconvenient from a user perspective as you have to keep track of which fields require what.

This PR is the first pass at masking these details from the user by changing boolean fields to actual `bool` types and handling the conversion at JSON marshal/unmarshal time. My goal here was to only require users to use bool.