### PR TITLE
add ModifyVirtualAddress

### DIFF
--- a/ltm.go
+++ b/ltm.go
@@ -1094,6 +1094,32 @@ func (b *BigIP) VirtualAddresses() (*VirtualAddresses, error) {
 func (b *BigIP) VirtualAddressStatus(vaddr, state string) error {
 	config := &VirtualAddress{}
 
+	switch state {
+	case "enable":
+		config.Enabled = true
+	case "disable":
+		config.Enabled = false
+	}
+
+	marshalJSON, err := json.Marshal(config)
+	if err != nil {
+		return err
+	}
+
+	req := &APIRequest{
+		Method:      "put",
+		URL:         fmt.Sprintf("%s/%s", uriVirtualAddress, vaddr),
+		Body:        string(marshalJSON),
+		ContentType: "application/json",
+	}
+
+	_, callErr := b.APICall(req)
+	return callErr
+}
+
+// ModifyVirtualAddress allows you to change any attribute of a virtual address. Fields that
+// can be modified are referenced in the VirtualAddress struct.
+func (b *BigIP) ModifyVirtualAddress(vaddr string, config *VirtualAddress) error {
 	marshalJSON, err := json.Marshal(config)
 	if err != nil {
 		return err

--- a/ltm_test.go
+++ b/ltm_test.go
@@ -90,6 +90,14 @@ func (s *LTMTestSuite) TestDeleteIRule() {
 	assert.Equal(s.T(), "DELETE", s.LastRequest.Method)
 }
 
+func (s *LTMTestSuite) TestModifyVirtualAddress() {
+	d := &VirtualAddress{}
+	s.Client.ModifyVirtualAddress("address1", d)
+
+	assert.Equal(s.T(), fmt.Sprintf("/mgmt/tm/%s/%s", uriVirtualAddress, "address1"), s.LastRequest.URL.Path)
+	assert.Equal(s.T(), "PUT", s.LastRequest.Method)
+}
+
 func (s *LTMTestSuite) TestGetPolicies() {
 	s.ResponseFunc = func(w http.ResponseWriter) {
 		w.Write([]byte(`{


### PR DESCRIPTION
Also fixes a bug in ```VirtualAddressStatus()``` where state wasn’t being used.

As an aside, @scottdware - I’m working with @RobWC on some changes here, and I just joked to him that even though I know nothing about F5s I am able to use this library. He says “I need it to do this” and points me to an API doc, and it turns out it’s easy to add to your code. In my book, the fact that someone with minimal domain knowledge can use and contribute is a sign of an excellent library design, so kudos.