### PR TITLE
Monitor credentials

### DIFF
--- a/examples/go-bigip_example.go
+++ b/examples/go-bigip_example.go
@@ -45,7 +45,7 @@ func main() {
 	f5.AddPoolMember("ssl_443_pool", "ssl-web-server-2:443")
 
 	// Create a monitor, and assign it to a pool.
-	f5.CreateMonitor("web_http_monitor", "http", 5, 16, "GET /\r\n", "200 OK")
+	f5.CreateMonitor("web_http_monitor", "http", 5, 16, "GET /\r\n", "200 OK", "", "")
 	f5.AddMonitorToPool("web_http_monitor", "web_farm_80_pool")
 
 	// Create a virtual server, with the above pool. The third field is the subnet

--- a/examples/go-bigip_example.go
+++ b/examples/go-bigip_example.go
@@ -45,7 +45,7 @@ func main() {
 	f5.AddPoolMember("ssl_443_pool", "ssl-web-server-2:443")
 
 	// Create a monitor, and assign it to a pool.
-	f5.CreateMonitor("web_http_monitor", "http", 5, 16, "GET /\r\n", "200 OK", "", "")
+	f5.CreateMonitor("web_http_monitor", "http", 5, 16, "GET /\r\n", "200 OK")
 	f5.AddMonitorToPool("web_http_monitor", "web_farm_80_pool")
 
 	// Create a virtual server, with the above pool. The third field is the subnet

--- a/ltm.go
+++ b/ltm.go
@@ -981,6 +981,10 @@ func (b *BigIP) CreateMonitor(name, parent string, interval, timeout int, send, 
 
 // Create a monitor by supplying a config
 func (b *BigIP) AddMonitor(config *Monitor) error {
+	if strings.Contains(config.ParentMonitor, "gateway") {
+		config.ParentMonitor = "gateway_icmp"
+	}
+
 	return b.post(config, uriLtm, uriMonitor, config.ParentMonitor)
 }
 
@@ -993,6 +997,10 @@ func (b *BigIP) DeleteMonitor(name, parent string) error {
 // one of "http", "https", "icmp", or "gateway icmp". Fields that
 // can be modified are referenced in the Monitor struct.
 func (b *BigIP) ModifyMonitor(name, parent string, config *Monitor) error {
+	if strings.Contains(config.ParentMonitor, "gateway") {
+		config.ParentMonitor = "gateway_icmp"
+	}
+
 	return b.put(config, uriLtm, uriMonitor, parent, name)
 }
 

--- a/ltm.go
+++ b/ltm.go
@@ -544,6 +544,7 @@ type Monitor struct {
 	Interval       int
 	IPDSCP         int
 	ManualResume   bool
+	Password       string
 	ReceiveString  string
 	ReceiveDisable string
 	Reverse        bool
@@ -552,6 +553,7 @@ type Monitor struct {
 	Timeout        int
 	Transparent    bool
 	UpInterval     int
+	Username       string
 }
 
 type monitorDTO struct {
@@ -565,6 +567,7 @@ type monitorDTO struct {
 	Interval       int    `json:"interval,omitempty"`
 	IPDSCP         int    `json:"ipDscp,omitempty"`
 	ManualResume   string `json:"manualResume,omitempty" bool:"enabled"`
+	Password       string `json:"password,omitempty"`
 	ReceiveString  string `json:"recv,omitempty"`
 	ReceiveDisable string `json:"recvDisable,omitempty"`
 	Reverse        string `json:"reverse,omitempty" bool:"enabled"`
@@ -573,6 +576,7 @@ type monitorDTO struct {
 	Timeout        int    `json:"timeout,omitempty"`
 	Transparent    string `json:"transparent,omitempty" bool:"enabled"`
 	UpInterval     int    `json:"upInterval,omitempty"`
+	Username       string `json:"username,omitempty"`
 }
 
 type Profiles struct {
@@ -959,7 +963,7 @@ func (b *BigIP) Monitors() ([]Monitor, error) {
 
 // CreateMonitor adds a new monitor to the BIG-IP system. <parent> must be one of "http", "https",
 // "icmp", or "gateway icmp".
-func (b *BigIP) CreateMonitor(name, parent string, interval, timeout int, send, receive string) error {
+func (b *BigIP) CreateMonitor(name, parent string, interval, timeout int, send, receive, user, pass string) error {
 	if strings.Contains(send, "\r\n") {
 		send = strings.Replace(send, "\r\n", "\\r\\n", -1)
 	}
@@ -975,6 +979,8 @@ func (b *BigIP) CreateMonitor(name, parent string, interval, timeout int, send, 
 		Timeout:       timeout,
 		SendString:    send,
 		ReceiveString: receive,
+		Username:      user,
+		Password:      pass,
 	}
 
 	return b.post(config, uriLtm, uriMonitor, parent)

--- a/ltm.go
+++ b/ltm.go
@@ -993,14 +993,6 @@ func (b *BigIP) DeleteMonitor(name, parent string) error {
 // one of "http", "https", "icmp", or "gateway icmp". Fields that
 // can be modified are referenced in the Monitor struct.
 func (b *BigIP) ModifyMonitor(name, parent string, config *Monitor) error {
-	if strings.Contains(config.SendString, "\r\n") {
-		config.SendString = strings.Replace(config.SendString, "\r\n", "\\r\\n", -1)
-	}
-
-	if strings.Contains(parent, "gateway") {
-		parent = "gateway_icmp"
-	}
-
 	return b.put(config, uriLtm, uriMonitor, parent, name)
 }
 

--- a/ltm_test.go
+++ b/ltm_test.go
@@ -410,8 +410,8 @@ func (s *LTMTestSuite) TestCreateMonitor() {
 	config := &Monitor{
 		Name:          "test-web-monitor",
 		ParentMonitor: "http",
-		Interval:      "15",
-		Timeout:       "5",
+		Interval:      15,
+		Timeout:       5,
 		SendString:    "GET /\r\n",
 		ReceiveString: "200 OK",
 		Username:      "monitoring",

--- a/ltm_test.go
+++ b/ltm_test.go
@@ -405,3 +405,34 @@ func (s *LTMTestSuite) TestModifyVirtualServer() {
 	}`, s.LastRequestBody)
 
 }
+
+func (s *LTMTestSuite) TestCreateMonitor() {
+	config := &Monitor{
+		Name:          "test-web-monitor",
+		ParentMonitor: "http",
+		Interval:      "15",
+		Timeout:       "5",
+		SendString:    "GET /\r\n",
+		ReceiveString: "200 OK",
+		Username:      "monitoring",
+		Password:      "monitoring",
+	}
+
+	s.Client.CreateMonitor(config.Name, config.ParentMonitor, config.Interval, config.Timeout, config.SendString, config.ReceiveString, config.Username, config.Password)
+
+	assert.Equal(s.T(), "POST", s.LastRequest.Method)
+	assert.Equal(s.T(), fmt.Sprintf("/mgmt/tm/%s/%s/%s", uriLtm, uriMonitor, config.ParentMonitor), s.LastRequest.URL.Path)
+}
+
+
+func (s *LTMTestSuite) TestDeleteMonitor() {
+	config := &Monitor{
+		Name:          "test-web-monitor",
+		ParentMonitor: "http",
+	}
+
+	s.Client.DeleteMonitor(config.Name, config.ParentMonitor)
+
+	assert.Equal(s.T(), "DELETE", s.LastRequest.Method)
+	assert.Equal(s.T(), fmt.Sprintf("/mgmt/tm/%s/%s/%s/%s", uriLtm, uriMonitor, config.ParentMonitor, config.Name), s.LastRequest.URL.Path)
+}

--- a/ltm_test.go
+++ b/ltm_test.go
@@ -414,14 +414,56 @@ func (s *LTMTestSuite) TestCreateMonitor() {
 		Timeout:       5,
 		SendString:    "GET /\r\n",
 		ReceiveString: "200 OK",
+	}
+
+	s.Client.CreateMonitor(config.Name, config.ParentMonitor, config.Interval, config.Timeout, config.SendString, config.ReceiveString)
+
+	assert.Equal(s.T(), "POST", s.LastRequest.Method)
+	assert.Equal(s.T(), fmt.Sprintf("/mgmt/tm/%s/%s/%s", uriLtm, uriMonitor, config.ParentMonitor), s.LastRequest.URL.Path)
+	assert.Equal(s.T(),`
+	{
+	   "name":"web_http_monitor",
+	   "defaultsFrom":"http",
+	   "interval":5,
+	   "manualResume":"disabled",
+	   "recv":"200 OK",
+	   "reverse":"disabled",
+	   "send":"GET /\\r\\n",
+	   "timeout":16,
+	   "transparent":"disabled"
+	}`, s.LastRequestBody)
+}
+
+func (s *LTMTestSuite) TestAddMonitor() {
+	config := &Monitor{
+		Name:          "test-web-monitor",
+		ParentMonitor: "http",
+		Interval:      15,
+		Timeout:       5,
+		SendString:    "GET /\r\n",
+		ReceiveString: "200 OK",
 		Username:      "monitoring",
 		Password:      "monitoring",
 	}
 
-	s.Client.CreateMonitor(config.Name, config.ParentMonitor, config.Interval, config.Timeout, config.SendString, config.ReceiveString, config.Username, config.Password)
+	s.Client.AddMonitor(config)
 
 	assert.Equal(s.T(), "POST", s.LastRequest.Method)
 	assert.Equal(s.T(), fmt.Sprintf("/mgmt/tm/%s/%s/%s", uriLtm, uriMonitor, config.ParentMonitor), s.LastRequest.URL.Path)
+	assert.Equal(s.T(),`
+	{
+	   "name":"test-web-monitor",
+	   "defaultsFrom":"http",
+	   "interval":15,
+	   "manualResume":"disabled",
+	   "password":"monitoring",
+	   "recv":"200 OK",
+	   "reverse":"disabled",
+	   "send":"GET /\\r\\n",
+	   "timeout":5,
+	   "transparent":"disabled",
+	   "username":"monitoring"
+	}`, s.LastRequestBody)
 }
 
 

--- a/ltm_test.go
+++ b/ltm_test.go
@@ -420,18 +420,7 @@ func (s *LTMTestSuite) TestCreateMonitor() {
 
 	assert.Equal(s.T(), "POST", s.LastRequest.Method)
 	assert.Equal(s.T(), fmt.Sprintf("/mgmt/tm/%s/%s/%s", uriLtm, uriMonitor, config.ParentMonitor), s.LastRequest.URL.Path)
-	assert.Equal(s.T(),`
-	{
-	   "name":"web_http_monitor",
-	   "defaultsFrom":"http",
-	   "interval":5,
-	   "manualResume":"disabled",
-	   "recv":"200 OK",
-	   "reverse":"disabled",
-	   "send":"GET /\\r\\n",
-	   "timeout":16,
-	   "transparent":"disabled"
-	}`, s.LastRequestBody)
+	assert.Equal(s.T(), `{"name":"test-web-monitor","defaultsFrom":"http","interval":15,"manualResume":"disabled","recv":"200 OK","reverse":"disabled","send":"GET /\\r\\n","timeout":5,"transparent":"disabled"}`, s.LastRequestBody)
 }
 
 func (s *LTMTestSuite) TestAddMonitor() {
@@ -450,20 +439,7 @@ func (s *LTMTestSuite) TestAddMonitor() {
 
 	assert.Equal(s.T(), "POST", s.LastRequest.Method)
 	assert.Equal(s.T(), fmt.Sprintf("/mgmt/tm/%s/%s/%s", uriLtm, uriMonitor, config.ParentMonitor), s.LastRequest.URL.Path)
-	assert.Equal(s.T(),`
-	{
-	   "name":"test-web-monitor",
-	   "defaultsFrom":"http",
-	   "interval":15,
-	   "manualResume":"disabled",
-	   "password":"monitoring",
-	   "recv":"200 OK",
-	   "reverse":"disabled",
-	   "send":"GET /\\r\\n",
-	   "timeout":5,
-	   "transparent":"disabled",
-	   "username":"monitoring"
-	}`, s.LastRequestBody)
+	assert.Equal(s.T(), `{"name":"test-web-monitor","defaultsFrom":"http","interval":15,"manualResume":"disabled","password":"monitoring","recv":"200 OK","reverse":"disabled","send":"GET /\\r\\n","timeout":5,"transparent":"disabled","username":"monitoring"}`, s.LastRequestBody)
 }
 
 

--- a/ltm_test.go
+++ b/ltm_test.go
@@ -442,7 +442,6 @@ func (s *LTMTestSuite) TestAddMonitor() {
 	assert.Equal(s.T(), `{"name":"test-web-monitor","defaultsFrom":"http","interval":15,"manualResume":"disabled","password":"monitoring","recv":"200 OK","reverse":"disabled","send":"GET /\\r\\n","timeout":5,"transparent":"disabled","username":"monitoring"}`, s.LastRequestBody)
 }
 
-
 func (s *LTMTestSuite) TestDeleteMonitor() {
 	config := &Monitor{
 		Name:          "test-web-monitor",


### PR DESCRIPTION
Adding the ability to apply a username and password for a monitor. I believe you can only apply a username and password to a monitor with specific parents (http/s, mysql, etc.) but I wasn't sure if I should check and error if the parent type does not support a username/password? edit: it actually returns 400 if you try to apply a user/pass to an unsupported parent monitor type