### PR TITLE
Fix issue where pool settings gets overwritten when adding a monitor

### DIFF
--- a/ltm.go
+++ b/ltm.go
@@ -1036,11 +1036,12 @@ func (b *BigIP) ModifyMonitor(name, parent string, config *Monitor) error {
 
 // AddMonitorToPool assigns the monitor, <monitor> to the given <pool>.
 func (b *BigIP) AddMonitorToPool(monitor, pool string) error {
-	config := &Pool{
-		Monitor: monitor,
+	p, err := b.GetPool(pool)
+	if err != nil {
+		return err
 	}
-
-	return b.put(config, uriLtm, uriPool, pool)
+	p.Monitor = monitor
+	return b.ModifyPool(pool, p)
 }
 
 // IRules returns a list of irules


### PR DESCRIPTION
Fixing it by getting a reference of the pool and adding the monitor to it.

#13 