### PR TITLE
Added DefaultAPICallTimeout 

### DIFF
--- a/bigip.go
+++ b/bigip.go
@@ -11,6 +11,11 @@ import (
 	"net/http"
 	"reflect"
 	"strings"
+	"time"
+)
+
+var (
+	DefaultAPICallTimeout = 60 * time.Second
 )
 
 // BigIP is a container for our session state.
@@ -131,7 +136,10 @@ func NewTokenSession(host, user, passwd, loginProviderName string) (b *BigIP, er
 // APICall is used to query the BIG-IP web API.
 func (b *BigIP) APICall(options *APIRequest) ([]byte, error) {
 	var req *http.Request
-	client := &http.Client{Transport: b.Transport}
+	client := &http.Client{
+		Transport: b.Transport,
+		Timeout: DefaultAPICallTimeout,
+	}
 	var format string
 	if strings.Contains(options.URL, "mgmt/") {
 		format = "%s/%s"


### PR DESCRIPTION
@scottdware 
@ivey 

The timeout on the Client wasn't set, if the F5 wasn't responsive (bad connectivity, bad server etc...) the client was waiting for a long time before timing out. 
Added a global DefaultAPICallTimeout variable which can be used to change the timeout on the API calls. (This way the API is still backwards compatible). By default it is set to 60secs. 
