### PR TITLE
Added Config Options struct for optional parameters

### DIFF
--- a/examples/go-bigip_example.go
+++ b/examples/go-bigip_example.go
@@ -7,7 +7,7 @@ import (
 
 func main() {
 	// Connect to the BIG-IP system.
-	f5 := bigip.NewSession("ltm.company.com", "admin", "secret")
+	f5 := bigip.NewSession("ltm.company.com", "admin", "secret", nil)
 
 	// Get a list of all VLAN's, and print their names to the console.
 	vlans, err := f5.Vlans()

--- a/ltm_test.go
+++ b/ltm_test.go
@@ -31,7 +31,7 @@ func (s *LTMTestSuite) SetupSuite() {
 		}
 	}))
 
-	s.Client = NewSession(s.Server.URL, "", "")
+	s.Client = NewSession(s.Server.URL, "", "", nil)
 }
 
 func (s *LTMTestSuite) TearDownSuite() {

--- a/net_test.go
+++ b/net_test.go
@@ -29,7 +29,7 @@ func (s *NetTestSuite) SetupSuite() {
 		}
 	}))
 
-	s.Client = NewSession(s.Server.URL, "", "")
+	s.Client = NewSession(s.Server.URL, "", "", nil)
 }
 
 func (s *NetTestSuite) TearDownSuite() {


### PR DESCRIPTION
@scottdware 
@ivey 

Added a new struct ```ConfigOptions```
Now the NewSession and NewTokenSession require this new parameter. 

Note, this breaks the backwards compatibility. (But in the future other optional parameters can be added using this same struct without breaking the API)