### PR TITLE
Adds the ability to define vlans on Virtual Server

### DIFF
--- a/ltm.go
+++ b/ltm.go
@@ -152,8 +152,10 @@ type VirtualServer struct {
 	SYNCookieStatus  string    `json:"synCookieStatus,omitempty"`
 	TranslateAddress string    `json:"translateAddress,omitempty"`
 	TranslatePort    string    `json:"translatePort,omitempty"`
+	VlansEnabled     bool      `json:"vlansEnabled,omitempty"`
 	VlansDisabled    bool      `json:"vlansDisabled,omitempty"`
 	VSIndex          int       `json:"vsIndex,omitempty"`
+	Vlans            []string  `json:"vlans,omitempty"`
 	Rules            []string  `json:"rules,omitempty"`
 	Profiles         []Profile `json:"profiles,omitempty"`
 	Policies         []string  `json:"policies,omitempty"`


### PR DESCRIPTION
Adds the ability to define vlans as enabled or disabled on Virtual Server.

**All Vlans and tunnels:**
![image](https://cloud.githubusercontent.com/assets/4100127/23287149/49289f92-fa01-11e6-9a90-83f839109448.png)
```
myVirtual := &bigip.VirtualServer{VlansEnabled: false, VlansDisabled: true, Vlans: []string{""}}
f5.ModifyVirtualServer("myVirtual", myVirtual)
```
**Disabled on specified Vlans/Tunnels:**
![image](https://cloud.githubusercontent.com/assets/4100127/23287275/01119f28-fa02-11e6-938f-9cf7bc97cbb0.png)
```
myVirtual := &bigip.VirtualServer{VlansEnabled: false, VlansDisabled: true, Vlans: []string{"/Common/http-tunnel"}}
f5.ModifyVirtualServer("myVirtual", myVirtual)
```
**Enabled on specified Vlans/Tunnels:**
![image](https://cloud.githubusercontent.com/assets/4100127/23287299/386f1b58-fa02-11e6-90ef-5366232c07dc.png)
```
myVirtual := &bigip.VirtualServer{VlansEnabled: true, VlansDisabled: false, Vlans: []string{"/Common/http-tunnel"}}
f5.ModifyVirtualServer("myVirtual", myVirtual)
```