### PR TITLE
Updated SSL profile ciphers value to all lowercase

### DIFF
--- a/ltm.go
+++ b/ltm.go
@@ -29,7 +29,7 @@ type ServerSSLProfile struct {
 	CacheTimeout                 int      `json:"cacheTimeout,omitempty"`
 	Cert                         string   `json:"cert,omitempty"`
 	Chain                        string   `json:"chain,omitempty"`
-	Ciphers                      string   `json:"Ciphers,omitempty"`
+	Ciphers                      string   `json:"ciphers,omitempty"`
 	DefaultsFrom                 string   `json:"defaultsFrom,omitempty"`
 	ExpireCertResponseControl    string   `json:"expireCertResponseControl,omitempty"`
 	GenericAlert                 string   `json:"genericAlert,omitempty"`
@@ -93,7 +93,7 @@ type ClientSSLProfile struct {
 	CertLifespan                    int      `json:"certLifespan,omitempty"`
 	CertLookupByIpaddrPort          string   `json:"certLookupByIpaddrPort,omitempty"`
 	Chain                           string   `json:"chain,omitempty"`
-	Ciphers                         string   `json:"Ciphers,omitempty"`
+	Ciphers                         string   `json:"ciphers,omitempty"`
 	ClientCertCa                    string   `json:"clientCertCa,omitempty"`
 	CrlFile                         string   `json:"crlFile,omitempty"`
 	DefaultsFrom                    string   `json:"defaultsFrom,omitempty"`


### PR DESCRIPTION
Current value "Ciphers" is not compatible with the API on BigIP version 11.6 and lower. 
Version 12 appears to have removed case sensitivity on key names.