### PR TITLE
Adds additional PoolMember operations

### DIFF
--- a/ltm.go
+++ b/ltm.go
@@ -219,99 +219,13 @@ type Pools struct {
 // Pool contains information about each pool. You can use all of these
 // fields when modifying a pool.
 type Pool struct {
-	Name                   string
-	Partition              string
-	FullPath               string
-	Generation             int
-	AllowNAT               bool
-	AllowSNAT              bool
-	IgnorePersistedWeight  bool
-	IPTOSToClient          string
-	IPTOSToServer          string
-	LinkQoSToClient        string
-	LinkQoSToServer        string
-	LoadBalancingMode      string
-	MinActiveMembers       int
-	MinUpMembers           int
-	MinUpMembersAction     string
-	MinUpMembersChecking   string
-	Monitor                string
-	QueueDepthLimit        int
-	QueueOnConnectionLimit string
-	QueueTimeLimit         int
-	ReselectTries          int
-	ServiceDownAction      string
-	SlowRampTime           int
-}
-
-// Pool Members contains a list of pool members within a pool on the BIG-IP system.
-type PoolMembers struct {
-	PoolMembers []PoolMember `json:"items"`
-}
-
-// Pool Member contains information about each individual member in a pool. You can use all
-// of these fields when modifying a pool member.
-type PoolMember struct {
-	Name            string
-	Partition       string
-	FullPath        string
-	Generation      int
-	Address         string
-	ConnectionLimit int
-	DynamicRatio    int
-	InheritProfile  bool
-	Logging         bool
-	Monitor         string
-	PriorityGroup   int
-	RateLimit       string
-	Ratio           int
-	Session         string
-	State           string
-}
-
-// PoolMember transfer object so we can mask the bool data munging
-type poolMemberDTO struct {
-	Name            string `json:"name,omitempty"`
-	Partition       string `json:"partition,omitempty"`
-	FullPath        string `json:"fullPath,omitempty"`
-	Generation      int    `json:"generation,omitempty"`
-	Address         string `json:"address,omitempty"`
-	ConnectionLimit int    `json:"connectionLimit,omitempty"`
-	DynamicRatio    int    `json:"dynamicRatio,omitempty"`
-	InheritProfile  string `json:"inheritProfile,omitempty" bool:"enabled"`
-	Logging         string `json:"logging,omitempty" bool:"enabled"`
-	Monitor         string `json:"monitor,omitempty"`
-	PriorityGroup   int    `json:"priorityGroup,omitempty"`
-	RateLimit       string `json:"rateLimit,omitempty" bool:"enabled"`
-	Ratio           int    `json:"ratio,omitempty"`
-	Session         string `json:"session,omitempty"`
-	State           string `json:"state,omitempty"`
-}
-
-func (p *PoolMember) MarshalJSON() ([]byte, error) {
-	var dto poolMemberDTO
-	marshal(&dto, p)
-	return json.Marshal(dto)
-}
-
-func (p *PoolMember) UnmarshalJSON(b []byte) error {
-	var dto poolMemberDTO
-	err := json.Unmarshal(b, &dto)
-	if err != nil {
-		return err
-	}
-	return marshal(p, &dto)
-}
-
-// Pool transfer object so we can mask the bool data munging
-type poolDTO struct {
 	Name                   string `json:"name,omitempty"`
 	Partition              string `json:"partition,omitempty"`
 	FullPath               string `json:"fullPath,omitempty"`
 	Generation             int    `json:"generation,omitempty"`
-	AllowNAT               string `json:"allowNat,omitempty" bool:"yes"`
-	AllowSNAT              string `json:"allowSnat,omitempty" bool:"yes"`
-	IgnorePersistedWeight  string `json:"ignorePersistedWeight,omitempty" bool:"enabled"`
+	AllowNAT               string `json:"allowNat,omitempty"`
+	AllowSNAT              string `json:"allowSnat,omitempty"`
+	IgnorePersistedWeight  string `json:"ignorePersistedWeight,omitempty"`
 	IPTOSToClient          string `json:"ipTosToClient,omitempty"`
 	IPTOSToServer          string `json:"ipTosToServer,omitempty"`
 	LinkQoSToClient        string `json:"linkQosToClient,omitempty"`
@@ -321,7 +235,7 @@ type poolDTO struct {
 	MinUpMembers           int    `json:"minUpMembers,omitempty"`
 	MinUpMembersAction     string `json:"minUpMembersAction,omitempty"`
 	MinUpMembersChecking   string `json:"minUpMembersChecking,omitempty"`
-	Monitor                string `json:"monitor"`
+	Monitor                string `json:"monitor,omitempty"`
 	QueueDepthLimit        int    `json:"queueDepthLimit,omitempty"`
 	QueueOnConnectionLimit string `json:"queueOnConnectionLimit,omitempty"`
 	QueueTimeLimit         int    `json:"queueTimeLimit,omitempty"`
@@ -330,24 +244,39 @@ type poolDTO struct {
 	SlowRampTime           int    `json:"slowRampTime,omitempty"`
 }
 
-func (p *Pool) MarshalJSON() ([]byte, error) {
-	var dto poolDTO
-	marshal(&dto, p)
-	return json.Marshal(dto)
-}
-
-func (p *Pool) UnmarshalJSON(b []byte) error {
-	var dto poolDTO
-	err := json.Unmarshal(b, &dto)
-	if err != nil {
-		return err
-	}
-	return marshal(p, &dto)
+// Pool Members contains a list of pool members within a pool on the BIG-IP system.
+type PoolMembers struct {
+	PoolMembers []PoolMember `json:"items"`
 }
 
 // poolMember is used only when adding members to a pool.
 type poolMember struct {
 	Name string `json:"name"`
+}
+
+// poolMembers is used only when modifying members on a pool.
+type poolMembers struct {
+	Members []PoolMember `json:"members"`
+}
+
+// Pool Member contains information about each individual member in a pool. You can use all
+// of these fields when modifying a pool member.
+type PoolMember struct {
+	Name            string `json:"name,omitempty"`
+	Partition       string `json:"partition,omitempty"`
+	FullPath        string `json:"fullPath,omitempty"`
+	Generation      int    `json:"generation,omitempty"`
+	Address         string `json:"address,omitempty"`
+	ConnectionLimit int    `json:"connectionLimit,omitempty"`
+	DynamicRatio    int    `json:"dynamicRatio,omitempty"`
+	InheritProfile  string `json:"inheritProfile,omitempty"`
+	Logging         string `json:"logging,omitempty"`
+	Monitor         string `json:"monitor,omitempty"`
+	PriorityGroup   int    `json:"priorityGroup,omitempty"`
+	RateLimit       string `json:"rateLimit,omitempty"`
+	Ratio           int    `json:"ratio,omitempty"`
+	Session         string `json:"session,omitempty"`
+	State           string `json:"state,omitempty"`
 }
 
 // VirtualServers contains a list of all virtual servers on the BIG-IP system.
@@ -1202,8 +1131,7 @@ func (b *BigIP) Pools() (*Pools, error) {
 	return &pools, nil
 }
 
-// PoolMembers returns a list of pool members for the given pool. Contained within the PoolMember
-// struct are the name and state fields.
+// PoolMembers returns a list of pool members for the given pool.
 func (b *BigIP) PoolMembers(name string) (*PoolMembers, error) {
 	var poolMembers PoolMembers
 	err, _ := b.getForEntity(&poolMembers, uriLtm, uriPool, name, uriPoolMember)
@@ -1221,19 +1149,67 @@ func (b *BigIP) AddPoolMember(pool, member string) error {
 		Name: member,
 	}
 
-	return b.post(config, uriLtm, uriPool, pool, "members")
+	return b.post(config, uriLtm, uriPool, pool, uriPoolMember)
+}
+
+// GetPoolMember returns the details of a member in the specified pool.
+func (b *BigIP) GetPoolMember(pool string, member string) (*PoolMember, error) {
+	var poolMember PoolMember
+	err, ok := b.getForEntity(&poolMember, uriLtm, uriPool, pool, uriPoolMember, member)
+
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
+	}
+
+	return &poolMember, nil
+}
+
+// CreatePoolMember creates a pool member for the specified pool.
+func (b *BigIP) CreatePoolMember(pool string, config *PoolMember) error {
+	return b.post(config, uriLtm, uriPool, pool, uriPoolMember)
+}
+
+// ModifyPoolMember will update the configuration of a particular pool member.
+func (b *BigIP) ModifyPoolMember(pool string, config *PoolMember) error {
+	member := config.FullPath
+	// These fields are not used when modifying a pool member; so omit them.
+	config.Name = ""
+	config.Partition = ""
+	config.FullPath = ""
+
+	// This cannot be modified for an existing pool member.
+	config.Address = ""
+
+	return b.put(config, uriLtm, uriPool, pool, uriPoolMember, member)
+}
+
+// UpdatePoolMembers does a replace-all-with for the members of a pool.
+func (b *BigIP) UpdatePoolMembers(pool string, pm *[]PoolMember) error {
+	config := &poolMembers{
+		Members: *pm,
+	}
+	return b.put(config, uriLtm, uriPool, pool)
+}
+
+// RemovePoolMember removes a pool member from the specified pool.
+func (b *BigIP) RemovePoolMember(pool string, config *PoolMember) error {
+	member := config.FullPath
+	return b.delete(uriLtm, uriPool, pool, uriPoolMember, member)
 }
 
 // DeletePoolMember removes a member from the given pool. <member> must be in the form
 // of <node>:<port>, i.e.: "web-server1:443".
-func (b *BigIP) DeletePoolMember(pool, member string) error {
-	return b.delete(uriLtm, uriPool, pool, "members", member)
+func (b *BigIP) DeletePoolMember(pool string, member string) error {
+	return b.delete(uriLtm, uriPool, pool, uriPoolMember, member)
 }
 
 // PoolMemberStatus changes the status of a pool member. <state> can be either
 // "enable" or "disable". <member> must be in the form of <node>:<port>,
 // i.e.: "web-server1:443".
-func (b *BigIP) PoolMemberStatus(pool, member, state string) error {
+func (b *BigIP) PoolMemberStatus(pool string, member string, state string) error {
 	config := &Node{}
 
 	switch state {
@@ -1248,15 +1224,20 @@ func (b *BigIP) PoolMemberStatus(pool, member, state string) error {
 		// 	config.Session = "user-disabled"
 	}
 
-	return b.put(config, uriLtm, uriPool, pool, "members", member)
+	return b.put(config, uriLtm, uriPool, pool, uriPoolMember, member)
 }
 
-// CreatePool adds a new pool to the BIG-IP system.
+// CreatePool adds a new pool to the BIG-IP system by name.
 func (b *BigIP) CreatePool(name string) error {
 	config := &Pool{
 		Name: name,
 	}
 
+	return b.post(config, uriLtm, uriPool)
+}
+
+// AddPool creates a new pool on the BIG-IP system.
+func (b *BigIP) AddPool(config *Pool) error {
 	return b.post(config, uriLtm, uriPool)
 }
 


### PR DESCRIPTION
Adds additional PoolMember operations.

- GetPoolMember
  - GetPoolMember returns the details of a member in the specified pool.
- CreatePoolMember
  - CreatePoolMember creates a pool member for the specified pool.
- ModifyPoolMember
  - ModifyPoolMember will update the configuration of a particular pool member.
- UpdatePoolMembers
  - UpdatePoolMembers does a replace-all-with for the members of a pool.
- RemovePoolMember
  - RemovePoolMember removes a pool member from the specified pool.

Adds some additional pool tests as well.

Also removed the PoolDTO and PoolMemberDTO. The driving factor for this is that any option that had the special "bool" marshaling going on, that value was always being sent regardless of if you wanted to re-configure that option or not. Looking around the web, it appears the best way to handle that is to use a pointer boolean on the struct (as described as an option here https://github.com/golang/go/issues/13284). But I figured that is a bit more of a breaking change, but possibly something to implement in the future.

