### PR TITLE
Expose 'AppService' on PoolMember and Node types, and support passing…

### DIFF
--- a/bigip.go
+++ b/bigip.go
@@ -164,7 +164,7 @@ func (b *BigIP) APICall(options *APIRequest) ([]byte, error) {
 		req.SetBasicAuth(b.User, b.Password)
 	}
 
-	//fmt.Println("REQ -- ", options.Method, " ", url," -- ",options.Body)
+	// fmt.Println("REQ -- ", options.Method, " ", url, " -- ", options.Body)
 
 	if len(options.ContentType) > 0 {
 		req.Header.Set("Content-Type", options.ContentType)
@@ -187,6 +187,7 @@ func (b *BigIP) APICall(options *APIRequest) ([]byte, error) {
 		return data, errors.New(fmt.Sprintf("HTTP %d :: %s", res.StatusCode, string(data[:])))
 	}
 
+	// fmt.Println("Resp --", res.StatusCode, " -- ", string(data))
 	return data, nil
 }
 

--- a/ltm.go
+++ b/ltm.go
@@ -337,6 +337,7 @@ type Nodes struct {
 // of these fields when modifying a node.
 type Node struct {
 	Name            string `json:"name,omitempty"`
+	AppService      string `json:"appService,omitempty"`
 	Partition       string `json:"partition,omitempty"`
 	FullPath        string `json:"fullPath,omitempty"`
 	Generation      int    `json:"generation,omitempty"`
@@ -464,6 +465,7 @@ type poolMembers struct {
 type PoolMember struct {
 	Name            string `json:"name,omitempty"`
 	Description     string `json:"description,omitempty"`
+	AppService      string `json:"appService,omitempty"`
 	Partition       string `json:"partition,omitempty"`
 	FullPath        string `json:"fullPath,omitempty"`
 	Generation      int    `json:"generation,omitempty"`
@@ -1703,7 +1705,7 @@ func (b *BigIP) DeletePoolMember(pool string, member string) error {
 // PoolMemberStatus changes the status of a pool member. <state> can be either
 // "enable" or "disable". <member> must be in the form of <node>:<port>,
 // i.e.: "web-server1:443".
-func (b *BigIP) PoolMemberStatus(pool string, member string, state string) error {
+func (b *BigIP) PoolMemberStatus(pool string, member string, state string, owner string) error {
 	config := &Node{}
 
 	switch state {
@@ -1716,6 +1718,10 @@ func (b *BigIP) PoolMemberStatus(pool string, member string, state string) error
 		// case "offline":
 		// 	config.State = "user-down"
 		// 	config.Session = "user-disabled"
+	}
+
+	if owner != "" {
+		config.AppService = owner
 	}
 
 	return b.put(config, uriLtm, uriPool, pool, uriPoolMember, member)

--- a/ltm.go
+++ b/ltm.go
@@ -1705,7 +1705,7 @@ func (b *BigIP) DeletePoolMember(pool string, member string) error {
 // PoolMemberStatus changes the status of a pool member. <state> can be either
 // "enable" or "disable". <member> must be in the form of <node>:<port>,
 // i.e.: "web-server1:443".
-func (b *BigIP) PoolMemberStatus(pool string, member string, state string, owner string) error {
+func (b *BigIP) PoolMemberStatus(pool string, member string, state string, owner ...string) error {
 	config := &Node{}
 
 	switch state {
@@ -1720,8 +1720,8 @@ func (b *BigIP) PoolMemberStatus(pool string, member string, state string, owner
 		// 	config.Session = "user-disabled"
 	}
 
-	if owner != "" {
-		config.AppService = owner
+	if owner[0] != "" {
+		config.AppService = owner[0]
 	}
 
 	return b.put(config, uriLtm, uriPool, pool, uriPoolMember, member)


### PR DESCRIPTION
… 'AppService' on PoolMemberStatus updates.

- Reasoning
All of our F5 resources are deployed via iApp application services. 
As of 12.1.0, the F5 REST API seems to complain if you don't specify the 'owner' when updating a PoolMember resource, and I suspect it will apply to other areas aswell... 