### PR TITLE
Fix monitor unmarshaling internal panic

### DIFF
--- a/ltm.go
+++ b/ltm.go
@@ -951,18 +951,18 @@ type Monitor struct {
 }
 
 type monitorDTO struct {
-	Name          string `json:"name,omitempty"`
-	Partition     string `json:"partition,omitempty"`
-	FullPath      string `json:"fullPath,omitempty"`
-	Generation    int    `json:"generation,omitempty"`
-	ParentMonitor string `json:"defaultsFrom,omitempty"`
-	Database      string `json:"database,omitempty"`
-	Description   string `json:"description,omitempty"`
-	Destination   string `json:"destination,omitempty"`
-	Interval      int    `json:"interval,omitempty"`
-	IPDSCP        int    `json:"ipDscp,omitempty"`
-	ManualResume  string `json:"manualResume,omitempty" bool:"enabled"`
-	// MonitorType    string
+	Name           string `json:"name,omitempty"`
+	Partition      string `json:"partition,omitempty"`
+	FullPath       string `json:"fullPath,omitempty"`
+	Generation     int    `json:"generation,omitempty"`
+	ParentMonitor  string `json:"defaultsFrom,omitempty"`
+	Database       string `json:"database,omitempty"`
+	Description    string `json:"description,omitempty"`
+	Destination    string `json:"destination,omitempty"`
+	Interval       int    `json:"interval,omitempty"`
+	IPDSCP         int    `json:"ipDscp,omitempty"`
+	ManualResume   string `json:"manualResume,omitempty" bool:"enabled"`
+	MonitorType    string `json:"monitorType,omitempty"`
 	Password       string `json:"password,omitempty"`
 	ReceiveColumn  string `json:"recvColumn,omitempty"`
 	ReceiveRow     string `json:"recvRow,omitempty"`
@@ -1961,10 +1961,10 @@ func (b *BigIP) AddMonitor(config *Monitor, monitorType string) error {
 }
 
 // GetVirtualServer retrieves a monitor by name. Returns nil if the monitor does not exist
-func (b *BigIP) GetMonitor(name string, parent string) (*Monitor, error) {
+func (b *BigIP) GetMonitor(name string, monitorType string) (*Monitor, error) {
 	// Add a verification that type is an accepted monitor type
 	var monitor Monitor
-	err, ok := b.getForEntity(&monitor, uriLtm, uriMonitor, parent, name)
+	err, ok := b.getForEntity(&monitor, uriLtm, uriMonitor, monitorType, name)
 	if err != nil {
 		return nil, err
 	}
@@ -1976,8 +1976,8 @@ func (b *BigIP) GetMonitor(name string, parent string) (*Monitor, error) {
 }
 
 // DeleteMonitor removes a monitor.
-func (b *BigIP) DeleteMonitor(name, parent string) error {
-	return b.delete(uriLtm, uriMonitor, parent, name)
+func (b *BigIP) DeleteMonitor(name, monitorType string) error {
+	return b.delete(uriLtm, uriMonitor, monitorType, name)
 }
 
 // ModifyMonitor allows you to change any attribute of a monitor. <monitorType> must

--- a/ltm_test.go
+++ b/ltm_test.go
@@ -837,15 +837,48 @@ func (s *LTMTestSuite) TestAddMonitor() {
 }
 
 func (s *LTMTestSuite) TestGetMonitor() {
+	s.ResponseFunc = func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{
+			"kind": "tm:ltm:monitor:http:httpstate",
+			"name": "test-web-monitor",
+			"partition": "Common",
+			"fullPath": "/Common/test-web-monitor",
+			"generation": 0,
+			"selfLink": "https://localhost/mgmt/tm/ltm/monitor/http/~Common~test-monitor?ver=13.1.0.2",
+			"adaptive": "disabled",
+			"adaptiveDivergenceType": "relative",
+			"adaptiveDivergenceValue": 25,
+			"adaptiveLimit": 200,
+			"adaptiveSamplingTimespan": 300,
+			"defaultsFrom": "/Common/http",
+			"destination": "*:*",
+			"interval": 500,
+			"ipDscp": 0,
+			"manualResume": "disabled",
+			"recv": "HTTP 1.1 302 Found",
+			"recvDisable": "HTTP/1.1 429",
+			"reverse": "disabled",
+			"send": "GET /some/path\\r\\n",
+			"timeUntilUp": 0,
+			"timeout": 999,
+			"transparent": "disabled",
+			"upInterval": 0
+		}`))
+	}
+
 	config := &Monitor{
 		Name:          "test-web-monitor",
 		ParentMonitor: "http",
 	}
 
-	s.Client.GetMonitor(config.Name, config.ParentMonitor)
+	m, err := s.Client.GetMonitor(config.Name, config.ParentMonitor)
 
+	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), "GET", s.LastRequest.Method)
 	assert.Equal(s.T(), fmt.Sprintf("/mgmt/tm/%s/%s/%s/%s", uriLtm, uriMonitor, config.ParentMonitor, config.Name), s.LastRequest.URL.Path)
+	assert.Equal(s.T(), "test-web-monitor", m.Name)
+	assert.Equal(s.T(), "HTTP 1.1 302 Found", m.ReceiveString)
+	assert.Equal(s.T(), "HTTP/1.1 429", m.ReceiveDisable)
 }
 
 func (s *LTMTestSuite) TestDeleteMonitor() {


### PR DESCRIPTION
_I'm sending up a small stream of PRs from an internal fork of go-bigip._

Without adding MonitorType to the DTO as well, the marshaling code internally panics, which ends up returning an error.