### PR TITLE
Make the virtual address support compatible with 13.1

### DIFF
--- a/ltm.go
+++ b/ltm.go
@@ -549,7 +549,7 @@ type VirtualAddress struct {
 	ICMPEcho              bool
 	InheritedTrafficGroup bool
 	Mask                  string
-	RouteAdvertisement    bool
+	RouteAdvertisement    string
 	ServerScope           string
 	TrafficGroup          string
 	Unit                  int
@@ -569,7 +569,7 @@ type virtualAddressDTO struct {
 	ICMPEcho              string `json:"icmpEcho,omitempty" bool:"enabled"`
 	InheritedTrafficGroup string `json:"inheritedTrafficGroup,omitempty" bool:"yes"`
 	Mask                  string `json:"mask,omitempty"`
-	RouteAdvertisement    string `json:"routeAdvertisement,omitempty" bool:"enabled"`
+	RouteAdvertisement    string `json:"routeAdvertisement,omitempty"`
 	ServerScope           string `json:"serverScope,omitempty"`
 	TrafficGroup          string `json:"trafficGroup,omitempty"`
 	Unit                  int    `json:"unit,omitempty"`

--- a/ltm_test.go
+++ b/ltm_test.go
@@ -356,7 +356,7 @@ func (s *LTMTestSuite) TestDeletePolicy() {
 	assert.Equal(s.T(), fmt.Sprintf("/mgmt/tm/%s/%s/foo", uriLtm, uriPolicy), s.LastRequest.URL.Path)
 }
 
-func (s *LTMTestSuite) TestCreateVitualAddress() {
+func (s *LTMTestSuite) TestCreateVirtualAddress() {
 
 	s.Client.CreateVirtualAddress("test-va", &VirtualAddress{Address: "10.10.10.10", ARP: true, AutoDelete: false})
 
@@ -374,7 +374,7 @@ func (s *LTMTestSuite) TestCreateVitualAddress() {
 
 }
 
-func (s *LTMTestSuite) TestCreateVitualAddressWithAdvertisement() {
+func (s *LTMTestSuite) TestCreateVirtualAddressWithAdvertisement() {
 
 	s.Client.CreateVirtualAddress("test-va", &VirtualAddress{Address: "10.10.10.10", ARP: true, AutoDelete: false, RouteAdvertisement: "selective"})
 
@@ -393,7 +393,7 @@ func (s *LTMTestSuite) TestCreateVitualAddressWithAdvertisement() {
 
 }
 
-func (s *LTMTestSuite) TestDeleteVitualAddress() {
+func (s *LTMTestSuite) TestDeleteVirtualAddress() {
 
 	s.Client.DeleteVirtualAddress("test-va")
 

--- a/ltm_test.go
+++ b/ltm_test.go
@@ -370,8 +370,26 @@ func (s *LTMTestSuite) TestCreateVitualAddress() {
 	"enabled":"no",
 	"floating":"disabled",
 	"icmpEcho":"disabled",
+	"inheritedTrafficGroup":"no"}`, s.LastRequestBody)
+
+}
+
+func (s *LTMTestSuite) TestCreateVitualAddressWithAdvertisement() {
+
+	s.Client.CreateVirtualAddress("test-va", &VirtualAddress{Address: "10.10.10.10", ARP: true, AutoDelete: false, RouteAdvertisement: "selective"})
+
+	assert.Equal(s.T(), "POST", s.LastRequest.Method)
+	assert.Equal(s.T(), fmt.Sprintf("/mgmt/tm/%s/%s", uriLtm, uriVirtualAddress), s.LastRequest.URL.Path)
+	assert.JSONEq(s.T(), `
+	{"name":"test-va",
+	"arp":"enabled",
+	"autoDelete":"false",
+	"address" : "10.10.10.10",
+	"enabled":"no",
+	"floating":"disabled",
+	"icmpEcho":"disabled",
 	"inheritedTrafficGroup":"no",
-	"routeAdvertisement":"disabled"}`, s.LastRequestBody)
+  "routeAdvertisement": "selective"}`, s.LastRequestBody)
 
 }
 


### PR DESCRIPTION
_I'm sending up a small stream of PRs from an internal fork of go-bigip._

It turns out that the RouteAdvertisement field is no longer just an enabled/disabled boolean on 13.1, but rather can be `selective` as well. This is a breaking change, so I'm not sure if changing it to a string rather than a bool is acceptable or not.