### PR TITLE
Use an old version of the policy API

### DIFF
--- a/bigip.go
+++ b/bigip.go
@@ -193,9 +193,15 @@ func (b *BigIP) APICall(options *APIRequest) ([]byte, error) {
 
 func (b *BigIP) iControlPath(parts []string) string {
 	var buffer bytes.Buffer
+	var lastPath int
+	if strings.HasPrefix(parts[len(parts)-1], "?") {
+		lastPath = len(parts) - 2
+	} else {
+		lastPath = len(parts) - 1
+	}
 	for i, p := range parts {
 		buffer.WriteString(strings.Replace(p, "/", "~", -1))
-		if i < len(parts)-1 {
+		if i < lastPath {
 			buffer.WriteString("/")
 		}
 	}
@@ -263,7 +269,6 @@ func (b *BigIP) patch(body interface{}, path ...string) error {
 	_, callErr := b.APICall(req)
 	return callErr
 }
-
 
 //Get a url and populate an entity. If the entity does not exist (404) then the
 //passed entity will be untouched and false will be returned as the second parameter.

--- a/ltm.go
+++ b/ltm.go
@@ -1045,6 +1045,9 @@ const (
 	CONTEXT_SERVER     = "serverside"
 	CONTEXT_CLIENT     = "clientside"
 	CONTEXT_ALL        = "all"
+
+	// Newer policy APIs have a draft-publish workflow that this library does not support.
+	policyVersionSuffix = "?ver=11.5.1"
 )
 
 var cidr = map[string]string{
@@ -2051,7 +2054,7 @@ func (b *BigIP) ModifyIRule(name string, irule *IRule) error {
 
 func (b *BigIP) Policies() (*Policies, error) {
 	var p Policies
-	err, _ := b.getForEntity(&p, uriLtm, uriPolicy)
+	err, _ := b.getForEntity(&p, uriLtm, uriPolicy, policyVersionSuffix)
 	if err != nil {
 		return nil, err
 	}
@@ -2062,7 +2065,7 @@ func (b *BigIP) Policies() (*Policies, error) {
 //Load a fully policy definition. Policies seem to be best dealt with as one big entity.
 func (b *BigIP) GetPolicy(name string) (*Policy, error) {
 	var p Policy
-	err, ok := b.getForEntity(&p, uriLtm, uriPolicy, name)
+	err, ok := b.getForEntity(&p, uriLtm, uriPolicy, name, policyVersionSuffix)
 	if err != nil {
 		return nil, err
 	}
@@ -2071,7 +2074,7 @@ func (b *BigIP) GetPolicy(name string) (*Policy, error) {
 	}
 
 	var rules PolicyRules
-	err, _ = b.getForEntity(&rules, uriLtm, uriPolicy, name, "rules")
+	err, _ = b.getForEntity(&rules, uriLtm, uriPolicy, name, "rules", policyVersionSuffix)
 	if err != nil {
 		return nil, err
 	}
@@ -2081,11 +2084,11 @@ func (b *BigIP) GetPolicy(name string) (*Policy, error) {
 		var a PolicyRuleActions
 		var c PolicyRuleConditions
 
-		err, _ = b.getForEntity(&a, uriLtm, uriPolicy, name, "rules", p.Rules[i].Name, "actions")
+		err, _ = b.getForEntity(&a, uriLtm, uriPolicy, name, "rules", p.Rules[i].Name, "actions", policyVersionSuffix)
 		if err != nil {
 			return nil, err
 		}
-		err, _ = b.getForEntity(&c, uriLtm, uriPolicy, name, "rules", p.Rules[i].Name, "conditions")
+		err, _ = b.getForEntity(&c, uriLtm, uriPolicy, name, "rules", p.Rules[i].Name, "conditions", policyVersionSuffix)
 		if err != nil {
 			return nil, err
 		}
@@ -2112,16 +2115,16 @@ func normalizePolicy(p *Policy) {
 //Create a new policy. It is not necessary to set the Ordinal fields on subcollections.
 func (b *BigIP) CreatePolicy(p *Policy) error {
 	normalizePolicy(p)
-	return b.post(p, uriLtm, uriPolicy)
+	return b.post(p, uriLtm, uriPolicy, policyVersionSuffix)
 }
 
 //Update an existing policy.
 func (b *BigIP) UpdatePolicy(name string, p *Policy) error {
 	normalizePolicy(p)
-	return b.put(p, uriLtm, uriPolicy, name)
+	return b.put(p, uriLtm, uriPolicy, name, policyVersionSuffix)
 }
 
 //Delete a policy by name.
 func (b *BigIP) DeletePolicy(name string) error {
-	return b.delete(uriLtm, uriPolicy, name)
+	return b.delete(uriLtm, uriPolicy, name, policyVersionSuffix)
 }

--- a/ltm_test.go
+++ b/ltm_test.go
@@ -151,6 +151,7 @@ func (s *LTMTestSuite) TestGetPolicies() {
 	p, e := s.Client.Policies()
 
 	assert.Nil(s.T(), e, "Fetching policy list should not return an error")
+	assert.Equal(s.T(), policyVersionSuffix, "?"+s.LastRequest.URL.RawQuery)
 	assert.Equal(s.T(), 2, len(p.Policies), "Wrong number of policies returned")
 	assert.Equal(s.T(), "policy1", p.Policies[0].Name)
 	assert.Equal(s.T(), "Common", p.Policies[0].Partition)
@@ -161,6 +162,7 @@ func (s *LTMTestSuite) TestGetPolicies() {
 
 func (s *LTMTestSuite) TestGetPolicy() {
 	s.ResponseFunc = func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(s.T(), policyVersionSuffix, "?"+s.LastRequest.URL.RawQuery)
 		if strings.HasSuffix(r.URL.Path, "rules") {
 			w.Write([]byte(`{
 			  "kind": "tm:ltm:policy:rules:rulescollectionstate",
@@ -256,6 +258,7 @@ func (s *LTMTestSuite) TestGetPolicy() {
 	p, err := s.Client.GetPolicy("my_policy")
 
 	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), policyVersionSuffix, "?"+s.LastRequest.URL.RawQuery)
 	assert.Equal(s.T(), "my_policy", p.Name)
 	assert.Equal(s.T(), 1, len(p.Rules), "Not enough rules")
 	assert.Equal(s.T(), 1, len(p.Rules[0].Actions), "Not enough actions")
@@ -310,6 +313,7 @@ func (s *LTMTestSuite) TestCreatePolicy() {
 
 	assert.Equal(s.T(), "POST", s.LastRequest.Method)
 	assert.Equal(s.T(), fmt.Sprintf("/mgmt/tm/%s/%s", uriLtm, uriPolicy), s.LastRequest.URL.Path)
+	assert.Equal(s.T(), policyVersionSuffix, "?"+s.LastRequest.URL.RawQuery)
 	assert.JSONEq(s.T(), `{"name":"test",
 		"controls":["forwarding"],
 		"requires":["http"],
@@ -347,6 +351,7 @@ func (s *LTMTestSuite) TestUpdatePolicy() {
 
 	assert.Equal(s.T(), "PUT", s.LastRequest.Method)
 	assert.Equal(s.T(), fmt.Sprintf("/mgmt/tm/%s/%s/foo", uriLtm, uriPolicy), s.LastRequest.URL.Path)
+	assert.Equal(s.T(), policyVersionSuffix, "?"+s.LastRequest.URL.RawQuery)
 }
 
 func (s *LTMTestSuite) TestDeletePolicy() {
@@ -354,6 +359,7 @@ func (s *LTMTestSuite) TestDeletePolicy() {
 
 	assert.Equal(s.T(), "DELETE", s.LastRequest.Method)
 	assert.Equal(s.T(), fmt.Sprintf("/mgmt/tm/%s/%s/foo", uriLtm, uriPolicy), s.LastRequest.URL.Path)
+	assert.Equal(s.T(), policyVersionSuffix, "?"+s.LastRequest.URL.RawQuery)
 }
 
 func (s *LTMTestSuite) TestCreateVitualAddress() {


### PR DESCRIPTION
_I'm sending up a small stream of PRs from an internal fork of go-bigip._

Newer versions use a draft-publish workflow that this library doesn't need to support. (And without specifying the version, the API rejects creation/updates.)