### PR TITLE
Fix VirtualServerPolicyNames

### DIFF
--- a/ltm.go
+++ b/ltm.go
@@ -582,10 +582,6 @@ type Policies struct {
 	Policies []Policy `json:"items"`
 }
 
-type VirtualServerPolicies struct {
-	PolicyRef Policies `json:"policiesReference"`
-}
-
 type Policy struct {
 	Name      string
 	Partition string
@@ -1867,13 +1863,13 @@ func (b *BigIP) VirtualServerProfiles(vs string) (*Profiles, error) {
 
 //Get the names of policies associated with a particular virtual server
 func (b *BigIP) VirtualServerPolicyNames(vs string) ([]string, error) {
-	var policies VirtualServerPolicies
+	var policies Policies
 	err, _ := b.getForEntity(&policies, uriLtm, uriVirtual, vs, "policies")
 	if err != nil {
 		return nil, err
 	}
-	retval := make([]string, 0, len(policies.PolicyRef.Policies))
-	for _, p := range policies.PolicyRef.Policies {
+	retval := make([]string, 0, len(policies.Policies))
+	for _, p := range policies.Policies {
 		retval = append(retval, p.FullPath)
 	}
 	return retval, nil

--- a/ltm_test.go
+++ b/ltm_test.go
@@ -962,28 +962,24 @@ func (s *LTMTestSuite) TestVirtualServerPolicies() {
 		w.Write([]byte(`{
 		  "kind": "tm:ltm:virtual:policies:policiescollectionstate",
 		  "selfLink": "https://localhost/mgmt/tm/ltm/virtual/foo/policies?ver=11.5.1",
-		  "policiesReference": {
-		    "link": "https://localhost/mgmt/tm/ltm/virtual/foo/policies?ver=11.5.1",
-		    "isSubcollection": true,
-		    "items": [
-		      {
-			"kind": "tm:ltm:virtual:policies:policiesstate",
-			"name": "policy1",
-			"partition": "Common",
-			"fullPath": "/Common/policy1",
-			"generation": 1,
-			"selfLink": "https://localhost/mgmt/tm/ltm/virtual/foo/policies/~Common~policy1?ver=11.5.1"
-		      },
-		      {
-			"kind": "tm:ltm:virtual:policies:policiesstate",
-			"name": "policy2",
-			"partition": "Common",
-			"fullPath": "/Common/policy2",
-			"generation": 1,
-			"selfLink": "https://localhost/mgmt/tm/ltm/virtual/foo/policies/~Common~policy2?ver=11.5.1"
-		      }
-		    ]
-		  }
+			"items": [
+				{
+					"kind": "tm:ltm:virtual:policies:policiesstate",
+					"name": "policy1",
+					"partition": "Common",
+					"fullPath": "/Common/policy1",
+					"generation": 1,
+					"selfLink": "https://localhost/mgmt/tm/ltm/virtual/foo/policies/~Common~policy1?ver=11.5.1"
+				},
+				{
+					"kind": "tm:ltm:virtual:policies:policiesstate",
+					"name": "policy2",
+					"partition": "Common",
+					"fullPath": "/Common/policy2",
+					"generation": 1,
+					"selfLink": "https://localhost/mgmt/tm/ltm/virtual/foo/policies/~Common~policy2?ver=11.5.1"
+				}
+			]
 		}`))
 	}
 
@@ -991,8 +987,7 @@ func (s *LTMTestSuite) TestVirtualServerPolicies() {
 
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), fmt.Sprintf("/mgmt/tm/%s/%s/foo/policies", uriLtm, uriVirtual), s.LastRequest.URL.Path)
-	assert.Equal(s.T(), "/Common/policy1", p[0])
-	assert.Equal(s.T(), "/Common/policy2", p[1])
+	assert.Equal(s.T(), []string{"/Common/policy1", "/Common/policy2"}, p)
 }
 
 func (s *LTMTestSuite) TestInternalDataGroups() {


### PR DESCRIPTION
I've tested this on 11.5.2 and 13.1.0 and confirmed that the structure returned doesn't have a nested policiesReference structure on either version.