### PR TITLE
Add support for managing sys folders

### DIFF
--- a/sys.go
+++ b/sys.go
@@ -1,7 +1,10 @@
 package bigip
 
+import "encoding/json"
+
 const (
 	uriSys            = "sys"
+	uriFolder         = "folder"
 	uriSyslog         = "syslog"
 	uriSoftware       = "software"
 	uriVolume         = "volume"
@@ -85,4 +88,127 @@ func (b *BigIP) Syslog() (*Syslog, error) {
 
 func (b *BigIP) SetSyslog(config Syslog) error {
 	return b.put(config, uriSys, uriSyslog)
+}
+
+// Folders contains a list of every folder on the BIG-IP system.
+type Folders struct {
+	Folders []Folder `json:"items"`
+}
+
+type folderDTO struct {
+	Name      string `json:"name,omitempty"`
+	Partition string `json:"partition,omitempty"`
+	SubPath   string `json:"subPath,omitempty"`
+	FullPath  string `json:"fullPath,omitempty"`
+
+	AppService  string `json:"appService,omitempty"`
+	Description string `json:"description,omitempty"`
+	// Set to "default" to inherit or a device group name to control. You can also set it to "non-default" to pin its device group to its current setting and turn off inheritance.
+	DeviceGroup string `json:"deviceGroup,omitempty"`
+	Hidden      string `json:"hidden,omitempty" bool:"true"`
+	NoRefCheck  string `json:"noRefCheck,omitempty" bool:"true"`
+	// Set to "default" to inherit or a traffic group name to control. You can also set it to "non-default" to pin its traffic group to its current setting and turn off inheritance.
+	TrafficGroup string `json:"trafficGroup,omitempty"`
+
+	// Read-only property. Set DeviceGroup to control.
+	InheritedDeviceGroup string `json:"inheritedDevicegroup,omitempty" bool:"true"`
+
+	// Read-only property. Set TrafficGroup to control.
+	InheritedTrafficGroup string `json:"inheritedTrafficGroup,omitempty" bool:"true"`
+}
+
+type Folder struct {
+	Name      string `json:"name,omitempty"`
+	Partition string `json:"partition,omitempty"`
+	SubPath   string `json:"subPath,omitempty"`
+	FullPath  string `json:"fullPath,omitempty"`
+
+	AppService   string `json:"appService,omitempty"`
+	Description  string `json:"description,omitempty"`
+	DeviceGroup  string `json:"deviceGroup,omitempty"`
+	Hidden       *bool  `json:"hidden,omitempty"`
+	NoRefCheck   *bool  `json:"noRefCheck,omitempty"`
+	TrafficGroup string `json:"trafficGroup,omitempty"`
+
+	// Read-only property. Set DeviceGroup to "default" or "non-default" to control.
+	InheritedDeviceGroup *bool `json:"inheritedDevicegroup,omitempty"`
+
+	// Read-only property. Set TrafficGroup to "default" or "non-default" to control.
+	InheritedTrafficGroup *bool `json:"inheritedTrafficGroup,omitempty"`
+}
+
+func (f *Folder) MarshalJSON() ([]byte, error) {
+	var dto folderDTO
+	marshal(&dto, f)
+	return json.Marshal(dto)
+}
+
+func (f *Folder) UnmarshalJSON(b []byte) error {
+	var dto folderDTO
+	err := json.Unmarshal(b, &dto)
+	if err != nil {
+		return err
+	}
+	return marshal(f, &dto)
+}
+
+// Folders returns a list of folders.
+func (b *BigIP) Folders() (*Folders, error) {
+	var folders Folders
+	err, _ := b.getForEntity(&folders, uriSys, uriFolder)
+	if err != nil {
+		return nil, err
+	}
+
+	return &folders, nil
+}
+
+// CreateFolder adds a new folder to the BIG-IP system.
+func (b *BigIP) CreateFolder(name string) error {
+	config := &Folder{
+		Name: name,
+	}
+
+	return b.post(config, uriSys, uriFolder)
+}
+
+// AddFolder adds a new folder by config to the BIG-IP system.
+func (b *BigIP) AddFolder(config *Folder) error {
+
+	return b.post(config, uriSys, uriFolder)
+}
+
+// GetFolder retrieves a Folder by name. Returns nil if the folder does not exist
+func (b *BigIP) GetFolder(name string) (*Folder, error) {
+	var folder Folder
+	err, ok := b.getForEntity(&folder, uriSys, uriFolder, name)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
+	}
+
+	return &folder, nil
+}
+
+// DeleteFolder removes a folder.
+func (b *BigIP) DeleteFolder(name string) error {
+	return b.delete(uriSys, uriFolder, name)
+}
+
+// ModifyFolder allows you to change any attribute of a folder. Fields that can
+// be modified are referenced in the Folder struct. This replaces the existing
+// configuration, so use PatchFolder if you want to change only particular
+// attributes.
+func (b *BigIP) ModifyFolder(name string, config *Folder) error {
+	return b.put(config, uriSys, uriFolder, name)
+}
+
+// PatchFolder allows you to change any attribute of a folder. Fields that can
+// be modified are referenced in the Folder struct. This changes only the
+// attributes provided, so use ModifyFolder if you want to replace the existing
+// configuration.
+func (b *BigIP) PatchFolder(name string, config *Folder) error {
+	return b.patch(config, uriSys, uriFolder, name)
 }

--- a/sys_test.go
+++ b/sys_test.go
@@ -1,0 +1,201 @@
+package bigip
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type SysTestSuite struct {
+	suite.Suite
+	Client          *BigIP
+	Server          *httptest.Server
+	LastRequest     *http.Request
+	LastRequestBody string
+	ResponseFunc    func(http.ResponseWriter, *http.Request)
+}
+
+func (s *SysTestSuite) SetupSuite() {
+	s.Server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := ioutil.ReadAll(r.Body)
+		s.LastRequestBody = string(body)
+		s.LastRequest = r
+		if s.ResponseFunc != nil {
+			s.ResponseFunc(w, r)
+		}
+	}))
+
+	s.Client = NewSession(s.Server.URL, "", "", nil)
+}
+
+func (s *SysTestSuite) TearDownSuite() {
+	s.Server.Close()
+}
+
+func (s *SysTestSuite) SetupTest() {
+	s.ResponseFunc = nil
+	s.LastRequest = nil
+}
+
+func (s *SysTestSuite) requireReserializesTo(expected string, actual interface{}, message string) {
+	b, err := json.Marshal(actual)
+	s.Require().Nil(err, message)
+
+	s.Require().JSONEq(expected, string(b), message)
+}
+
+func TestSysSuite(t *testing.T) {
+	suite.Run(t, new(SysTestSuite))
+}
+
+func (s *SysTestSuite) TestFolders() {
+	resp := `{
+  "items": [
+    {
+      "name": "/",
+      "fullPath": "/",
+      "deviceGroup": "none",
+      "hidden": "false",
+      "inheritedDevicegroup": "false",
+      "inheritedTrafficGroup": "false",
+      "noRefCheck": "false",
+      "trafficGroup": "/Common/traffic-group-1"
+    },
+    {
+      "name": "Common",
+      "subPath": "/",
+      "fullPath": "/Common",
+      "deviceGroup": "none",
+      "hidden": "false",
+      "inheritedDevicegroup": "true",
+      "inheritedTrafficGroup": "true",
+      "noRefCheck": "false",
+      "trafficGroup": "/Common/traffic-group-1"
+    },
+    {
+      "name": "Drafts",
+      "partition": "Common",
+      "fullPath": "/Common/Drafts",
+      "deviceGroup": "none",
+      "hidden": "false",
+      "inheritedDevicegroup": "true",
+      "inheritedTrafficGroup": "true",
+      "noRefCheck": "false",
+      "trafficGroup": "/Common/traffic-group-1"
+    },
+    {
+      "name": "test",
+      "partition": "Common",
+      "fullPath": "/Common/test",
+      "deviceGroup": "none",
+      "hidden": "false",
+      "inheritedDevicegroup": "true",
+      "inheritedTrafficGroup": "true",
+      "noRefCheck": "false",
+      "trafficGroup": "/Common/traffic-group-1"
+    }
+  ]
+}`
+
+	s.ResponseFunc = func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(resp))
+	}
+
+	folders, err := s.Client.Folders()
+
+	require.Nil(s.T(), err, "Error loading folders")
+	assert.Equal(s.T(), fmt.Sprintf("/mgmt/tm/%s/%s", uriSys, uriFolder), s.LastRequest.URL.Path, "Wrong uri to fetch folders")
+	assert.Equal(s.T(), 4, len(folders.Folders), "Wrong number of folders")
+	assert.Equal(s.T(), "/", folders.Folders[0].Name)
+	assert.Equal(s.T(), "Common", folders.Folders[1].Name)
+	assert.Equal(s.T(), "Drafts", folders.Folders[2].Name)
+	assert.Equal(s.T(), "test", folders.Folders[3].Name)
+
+	s.requireReserializesTo(resp, folders, "Folders should reserialize to itself")
+}
+
+func (s *SysTestSuite) TestCreateFolder() {
+	err := s.Client.CreateFolder("/Common/test")
+
+	require.Nil(s.T(), err, "Error creating folder")
+	assert.Equal(s.T(), fmt.Sprintf("/mgmt/tm/%s/%s", uriSys, uriFolder), s.LastRequest.URL.Path, "Wrong uri to create folders")
+	assert.Equal(s.T(), "POST", s.LastRequest.Method)
+	assert.JSONEq(s.T(), `{"name":"/Common/test"}`, s.LastRequestBody)
+}
+
+func (s *SysTestSuite) TestAddFolder() {
+	folder := Folder{
+		Name:         "/Common/test",
+		TrafficGroup: "default",
+		NoRefCheck:   Bool(true),
+	}
+	err := s.Client.AddFolder(&folder)
+
+	require.Nil(s.T(), err, "Error adding folder")
+	assert.Equal(s.T(), fmt.Sprintf("/mgmt/tm/%s/%s", uriSys, uriFolder), s.LastRequest.URL.Path, "Wrong uri to create folders")
+	assert.Equal(s.T(), "POST", s.LastRequest.Method)
+	assert.JSONEq(s.T(), `{"name":"/Common/test", "trafficGroup": "default", "noRefCheck": "true"}`, s.LastRequestBody)
+}
+
+func (s *SysTestSuite) TestGetFolder() {
+	resp := `{
+  "name": "test",
+  "partition": "Common",
+  "fullPath": "/Common/test",
+  "deviceGroup": "none",
+  "hidden": "false",
+  "inheritedDevicegroup": "true",
+  "inheritedTrafficGroup": "true",
+  "noRefCheck": "false",
+  "trafficGroup": "/Common/traffic-group-1"
+  }`
+
+	s.ResponseFunc = func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(resp))
+	}
+
+	folder, err := s.Client.GetFolder("/Common/test")
+
+	require.Nil(s.T(), err, "Error getting folder")
+	assert.Equal(s.T(), fmt.Sprintf("/mgmt/tm/%s/%s/%s", uriSys, uriFolder, "~Common~test"), s.LastRequest.URL.Path, "Wrong uri to fetch folders")
+	s.requireReserializesTo(resp, folder, "Folder should reserialize to itself")
+}
+
+func (s *SysTestSuite) TestDeleteFolder() {
+	err := s.Client.DeleteFolder("/Common/test")
+
+	require.Nil(s.T(), err, "Error deleting folder")
+	assert.Equal(s.T(), fmt.Sprintf("/mgmt/tm/%s/%s/%s", uriSys, uriFolder, "~Common~test"), s.LastRequest.URL.Path, "Wrong uri to create folders")
+	assert.Equal(s.T(), "DELETE", s.LastRequest.Method)
+}
+
+func (s *SysTestSuite) TestModifyFolder() {
+	folder := Folder{
+		TrafficGroup: "default",
+		NoRefCheck:   Bool(true),
+	}
+	err := s.Client.ModifyFolder("/Common/test", &folder)
+
+	require.Nil(s.T(), err, "Error modifying folder")
+	assert.Equal(s.T(), fmt.Sprintf("/mgmt/tm/%s/%s/%s", uriSys, uriFolder, "~Common~test"), s.LastRequest.URL.Path, "Wrong uri to fetch folders")
+	assert.Equal(s.T(), "PUT", s.LastRequest.Method)
+}
+
+func (s *SysTestSuite) TestPatchFolder() {
+	folder := Folder{
+		TrafficGroup: "default",
+		NoRefCheck:   Bool(true),
+	}
+	err := s.Client.PatchFolder("/Common/test", &folder)
+
+	require.Nil(s.T(), err, "Error patching folder")
+	assert.Equal(s.T(), fmt.Sprintf("/mgmt/tm/%s/%s/%s", uriSys, uriFolder, "~Common~test"), s.LastRequest.URL.Path, "Wrong uri to fetch folders")
+	assert.Equal(s.T(), "PATCH", s.LastRequest.Method)
+}


### PR DESCRIPTION
Use bool ptrs to make sure we're not serializing false fields when they're not explicitly set. That's a departure from existing structures, but I don't see a better option other than marshaling to and from strings instead of bools.