### PR TITLE
use pointer instead of int

### DIFF
--- a/bigip.go
+++ b/bigip.go
@@ -191,6 +191,13 @@ func (b *BigIP) APICall(options *APIRequest) ([]byte, error) {
 	return data, nil
 }
 
+// modifies int to *int, needed if we want use 0 values in int and encode to json
+func (b *BigIP) IntToPointer(integer int) *int {
+	var i int
+	i = integer
+	return &i
+}
+
 func (b *BigIP) iControlPath(parts []string) string {
 	var buffer bytes.Buffer
 	var lastPath int

--- a/ltm.go
+++ b/ltm.go
@@ -450,7 +450,7 @@ type Pool struct {
 	QueueTimeLimit         int    `json:"queueTimeLimit,omitempty"`
 	ReselectTries          int    `json:"reselectTries,omitempty"`
 	ServiceDownAction      string `json:"serviceDownAction,omitempty"`
-	SlowRampTime           int    `json:"slowRampTime,omitempty"`
+	SlowRampTime           *int   `json:"slowRampTime,omitempty"`
 
 	// Setting this field atomically updates all members.
 	Members *[]PoolMember `json:"members,omitempty"`

--- a/ltm_test.go
+++ b/ltm_test.go
@@ -636,13 +636,14 @@ func (s *LTMTestSuite) TestModifyPool() {
 		LoadBalancingMode: "round-robin",
 		AllowSNAT:         "yes",
 		AllowNAT:          "yes",
+		SlowRampTime:      s.Client.IntToPointer(0),
 	}
 
 	s.Client.ModifyPool("/Common/test-pool", config)
 
 	assert.Equal(s.T(), "PUT", s.LastRequest.Method)
 	assert.Equal(s.T(), fmt.Sprintf("/mgmt/tm/%s/%s/%s", uriLtm, uriPool, "~Common~test-pool"), s.LastRequest.URL.Path)
-	assert.JSONEq(s.T(), `{"name":"test-pool","partition":"Common","allowNat":"yes","allowSnat":"yes","loadBalancingMode":"round-robin","monitor":"/Common/http"}`, s.LastRequestBody)
+	assert.JSONEq(s.T(), `{"name":"test-pool","partition":"Common","allowNat":"yes","allowSnat":"yes","loadBalancingMode":"round-robin","monitor":"/Common/http","slowRampTime":0}`, s.LastRequestBody)
 }
 
 func (s *LTMTestSuite) TestModifyPoolWithMembers() {


### PR DESCRIPTION
according this https://stackoverflow.com/questions/38486564/golang-unmarshal-marshal-json-with-int-set-to-0-does-not-seem-to-work we should use `*int` instead of `int` if we want marshal `0` value.