### PR TITLE
issues-85: ltm updatepoolmembers as PATCH not PUT

### DIFF
--- a/ltm.go
+++ b/ltm.go
@@ -1677,7 +1677,7 @@ func (b *BigIP) UpdatePoolMembers(pool string, pm *[]PoolMember) error {
 	config := &poolMembers{
 		Members: *pm,
 	}
-	return b.put(config, uriLtm, uriPool, pool)
+	return b.patch(config, uriLtm, uriPool, pool)
 }
 
 // RemovePoolMember removes a pool member from the specified pool.

--- a/ltm_test.go
+++ b/ltm_test.go
@@ -1061,6 +1061,29 @@ func (s *LTMTestSuite) TestModifyPoolMember() {
 	assert.Equal(s.T(), `{"monitor":"/Common/icmp"}`, s.LastRequestBody)
 }
 
+func (s *LTMTestSuite) TestUpdatePoolMembers() {
+	pool := "/Common/test-pool"
+	config := &[]PoolMember{
+		{
+			Name:      "test-pool-member:80",
+			Partition: "Common",
+			FullPath:  "/Common/test-pool-member:80",
+		},
+		{
+			Name:      "test-pool-member2:80",
+			Partition: "Common",
+			FullPath:  "/Common/test-pool-member2:80",
+		},
+	}
+
+	s.Client.UpdatePoolMembers(pool, config)
+
+	fmt.Println(s.LastRequest.URL)
+	assert.Equal(s.T(), "PATCH", s.LastRequest.Method)
+	assert.Equal(s.T(), fmt.Sprintf("/mgmt/tm/%s/%s/%s", uriLtm, uriPool, "~Common~test-pool"), s.LastRequest.URL.Path)
+	assert.Equal(s.T(), `{"members":[{"name":"test-pool-member:80","partition":"Common","fullPath":"/Common/test-pool-member:80","monitor":"/Common/icmp"},{"name":"test-pool-member2:80","partition":"Common","fullPath":"/Common/test-pool-member2:80","monitor":"/Common/icmp"}]}`, s.LastRequestBody)
+}
+
 func (s *LTMTestSuite) TestCreateMonitor() {
 	config := &Monitor{
 		Name:          "test-web-monitor",

--- a/ltm_test.go
+++ b/ltm_test.go
@@ -1068,11 +1068,13 @@ func (s *LTMTestSuite) TestUpdatePoolMembers() {
 			Name:      "test-pool-member:80",
 			Partition: "Common",
 			FullPath:  "/Common/test-pool-member:80",
+			Monitor:   "/Common/icmp",
 		},
 		{
 			Name:      "test-pool-member2:80",
 			Partition: "Common",
 			FullPath:  "/Common/test-pool-member2:80",
+			Monitor:   "/Common/icmp",
 		},
 	}
 


### PR DESCRIPTION
ltm.UpdatePoolMembers replaces existing pool member info correctly but also resets all other pool properties to default values. For example, if you had a health monitor applied to the pool before, after calling UpdatePoolMembers, membership is correct but monitor is now none. This would apparently be due to the call being a PUT rather than a PATCH.

Updating UpdatePoolMembers to use PATCH fixes the problem.  Pool membership is completely replaced based on the config argument.  No other pool property is effected by the operation -- that use case is covered by ltm.ModifyPool() .