### PR TITLE
Added PatchVirtualServer and PatchVirtualAddress functions 

### DIFF
--- a/ltm.go
+++ b/ltm.go
@@ -1824,9 +1824,15 @@ func (b *BigIP) DeleteVirtualServer(name string) error {
 }
 
 // ModifyVirtualServer allows you to change any attribute of a virtual server. Fields that
-// can be modified are referenced in the VirtualServer struct.
+// can be modified are referenced in the VirtualServer struct. Set all the attributes.
 func (b *BigIP) ModifyVirtualServer(name string, config *VirtualServer) error {
 	return b.put(config, uriLtm, uriVirtual, name)
+}
+
+// PatchVirtualServer allows you to change any attribute of a virtual server. Fields that
+// can be modified are referenced in the VirtualServer struct. Sets only the attributes specified.
+func (b *BigIP) PatchVirtualServer(name string, config *VirtualServer) error {
+	return b.patch(config, uriLtm, uriVirtual, name)
 }
 
 // VirtualServerProfiles gets the profiles currently associated with a virtual server.
@@ -1891,9 +1897,15 @@ func (b *BigIP) VirtualAddressStatus(vaddr, state string) error {
 }
 
 // ModifyVirtualAddress allows you to change any attribute of a virtual address. Fields that
-// can be modified are referenced in the VirtualAddress struct.
+// can be modified are referenced in the VirtualAddress struct. Sets all the attributes.
 func (b *BigIP) ModifyVirtualAddress(vaddr string, config *VirtualAddress) error {
 	return b.put(config, uriLtm, uriVirtualAddress, vaddr)
+}
+
+// PatchVirtualAddress allows you to change any attribute of a virtual address. Fields that
+// can be modified are referenced in the VirtualAddress struct. Sets only the attributes specified.
+func (b *BigIP) PatchVirtualAddress(vaddr string, config *VirtualAddress) error {
+	return b.patch(config, uriLtm, uriVirtualAddress, vaddr)
 }
 
 func (b *BigIP) DeleteVirtualAddress(vaddr string) error {

--- a/ltm_test.go
+++ b/ltm_test.go
@@ -100,6 +100,14 @@ func (s *LTMTestSuite) TestModifyVirtualAddress() {
 	assert.Equal(s.T(), "PUT", s.LastRequest.Method)
 }
 
+func (s *LTMTestSuite) TestPatchVirtualAddress() {
+	d := &VirtualAddress{}
+	s.Client.PatchVirtualAddress("address1", d)
+
+	assert.Equal(s.T(), fmt.Sprintf("/mgmt/tm/%s/%s/%s", uriLtm, uriVirtualAddress, "address1"), s.LastRequest.URL.Path)
+	assert.Equal(s.T(), "PATCH", s.LastRequest.Method)
+}
+
 func (s *LTMTestSuite) TestGetPolicies() {
 	s.ResponseFunc = func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`{
@@ -456,6 +464,30 @@ func (s *LTMTestSuite) TestModifyVirtualServer() {
 	s.Client.ModifyVirtualServer("test", vs)
 
 	assert.Equal(s.T(), "PUT", s.LastRequest.Method)
+	assert.Equal(s.T(), fmt.Sprintf("/mgmt/tm/%s/%s/test", uriLtm, uriVirtual), s.LastRequest.URL.Path)
+	assert.JSONEq(s.T(), `
+	{"name":"test",
+	"sourceAddressTranslation":{},
+	"profiles":[
+		{"name":"/Common/tcp","context":"clientside"},
+		{"name":"/Common/tcp","context":"serverside"}
+	]
+	}`, s.LastRequestBody)
+
+}
+
+func (s *LTMTestSuite) TestPatchVirtualServer() {
+	vs := &VirtualServer{
+		Name: "test",
+		Profiles: []Profile{
+			Profile{Name: "/Common/tcp", Context: CONTEXT_CLIENT},
+			Profile{Name: "/Common/tcp", Context: CONTEXT_SERVER}},
+		//TODO: test more
+	}
+
+	s.Client.PatchVirtualServer("test", vs)
+
+	assert.Equal(s.T(), "PATCH", s.LastRequest.Method)
 	assert.Equal(s.T(), fmt.Sprintf("/mgmt/tm/%s/%s/test", uriLtm, uriVirtual), s.LastRequest.URL.Path)
 	assert.JSONEq(s.T(), `
 	{"name":"test",


### PR DESCRIPTION
Added PatchVirtualServer and PatchVirtualAddress functions  to update VirtualServer and VirtualAddress objects using patch method.

Solves issue https://github.com/scottdware/go-bigip/issues/80

Tested using Azure f5 bigip virtual appliance 12.1.4 and working fine. 