### PR TITLE
Add file upload

### DIFF
--- a/cm.go
+++ b/cm.go
@@ -2,6 +2,9 @@ package bigip
 
 import (
 	"errors"
+	"fmt"
+	"os"
+	"strings"
 )
 
 // Devices contains a list of every device on the BIG-IP system.
@@ -28,8 +31,10 @@ type ConfigSync struct {
 }
 
 const (
-	uriCm     = "cm"
-	uriDevice = "device"
+	uriCm                   = "cm"
+	uriDevice               = "device"
+	uriAutodeploy           = "autodeploy"
+	uriSoftwareImageUploads = "software-image-uploads"
 )
 
 // Devices returns a list of devices.
@@ -67,4 +72,17 @@ func (b *BigIP) ConfigSyncToGroup(name string) error {
 		UtilCmdArgs: args,
 	}
 	return b.post(config, uriCm)
+}
+
+// Upload a software image
+func (b *BigIP) UploadSoftwareImage(f *os.File) (*Upload, error) {
+	if !strings.HasSuffix(f.Name(), ".iso") {
+		err := fmt.Errorf("File must have .iso extension")
+		return nil, err
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	return b.Upload(f, info.Size(), uriCm, uriAutodeploy, uriSoftwareImageUploads, info.Name())
 }

--- a/shared.go
+++ b/shared.go
@@ -1,7 +1,10 @@
 package bigip
 
 import (
+	"bytes"
 	"fmt"
+	"os"
+	"strings"
 	"time"
 )
 
@@ -99,6 +102,8 @@ const (
 	uriLicensing    = "licensing"
 	uriActivation   = "activation"
 	uriRegistration = "registration"
+	uriFileTransfer = "file-transfer"
+	uriUploads      = "uploads"
 
 	activationComplete   = "LICENSING_COMPLETE"
 	activationInProgress = "LICENSING_ACTIVATION_IN_PROGRESS"
@@ -251,4 +256,24 @@ loop:
 	}
 
 	return fmt.Errorf("Timed out after %s", timeout)
+}
+
+// Upload a file
+func (b *BigIP) UploadFile(f *os.File) (*Upload, error) {
+	if strings.HasSuffix(f.Name(), ".iso") {
+		err := fmt.Errorf("File must not have .iso extension")
+		return nil, err
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	return b.Upload(f, info.Size(), uriShared, uriFileTransfer, uriUploads, info.Name())
+}
+
+// Upload a file from a byte slice
+func (b *BigIP) UploadBytes(data []byte, filename string) (*Upload, error) {
+	r := bytes.NewReader(data)
+	size := int64(len(data))
+	return b.Upload(r, size, uriShared, uriFileTransfer, uriUploads, filename)
 }

--- a/shared_test.go
+++ b/shared_test.go
@@ -425,11 +425,3 @@ func (s *SharedTestSuite) TestUploadBytes() {
 	s.Require().Equal(fmt.Sprintf("0-%d/%d", size-1, size), s.LastRequest.Header.Get("Content-Range"), "Wrong Content-Range header")
 	s.Require().Equal(fmt.Sprintf("/mgmt/shared/file-transfer/uploads/%s", filename), s.LastRequest.URL.Path, "Wrong uri to upload file")
 }
-
-func (s *SharedTestSuite) TestUploadIso() {
-	tmp, err := ioutil.TempFile("", "test*.iso")
-	defer os.Remove(tmp.Name())
-	_, err = s.Client.UploadFile(tmp)
-	s.Require().Error(err)
-	s.Require().Equal("File must not have .iso extension", err.Error(), "Should not allow .iso files")
-}

--- a/shared_test.go
+++ b/shared_test.go
@@ -6,6 +6,8 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path"
 	"testing"
 	"time"
 
@@ -383,4 +385,51 @@ func (s *SharedTestSuite) TestActivateEula() {
 	s.Require().Equal(fmt.Sprintf("/mgmt/tm/%s/%s/%s", uriShared, uriLicensing, uriRegistration), s.LastRequest.URL.Path, "Wrong uri to install license")
 	s.Require().Equal("PUT", s.LastRequest.Method, "Wrong method to install license")
 	s.Require().JSONEq(`{"licenseText": "this is a new license\nline 2"}`, s.LastRequestBody)
+}
+
+func (s *SharedTestSuite) TestUploadFile() {
+	tmp, err := ioutil.TempFile("", "test")
+	defer os.Remove(tmp.Name())
+	content := []byte("test file content")
+	size := len(content)
+	tmp.Write(content)
+	tmp.Close()
+	f, _ := os.Open(tmp.Name())
+	filename := path.Base(tmp.Name())
+
+	s.ResponseFunc = func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{}`))
+	}
+
+	upload, err := s.Client.UploadFile(f)
+	s.Require().Nil(err, "Error uploading file")
+	s.Require().NotNil(upload, "Upload response should not be nil")
+	s.Require().Equal("application/octet-stream", s.LastRequest.Header.Get("Content-Type"), "Wrong Content-Type header")
+	s.Require().Equal(fmt.Sprintf("0-%d/%d", size-1, size), s.LastRequest.Header.Get("Content-Range"), "Wrong Content-Range header")
+	s.Require().Equal(fmt.Sprintf("/mgmt/shared/file-transfer/uploads/%s", filename), s.LastRequest.URL.Path, "Wrong uri to upload file")
+}
+
+func (s *SharedTestSuite) TestUploadBytes() {
+	b := []byte("test byte content")
+	size := len(b)
+	filename := "test.txt"
+
+	s.ResponseFunc = func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{}`))
+	}
+
+	upload, err := s.Client.UploadBytes(b, filename)
+	s.Require().Nil(err, "Error uploading file")
+	s.Require().NotNil(upload, "Upload response should not be nil")
+	s.Require().Equal("application/octet-stream", s.LastRequest.Header.Get("Content-Type"), "Wrong Content-Type header")
+	s.Require().Equal(fmt.Sprintf("0-%d/%d", size-1, size), s.LastRequest.Header.Get("Content-Range"), "Wrong Content-Range header")
+	s.Require().Equal(fmt.Sprintf("/mgmt/shared/file-transfer/uploads/%s", filename), s.LastRequest.URL.Path, "Wrong uri to upload file")
+}
+
+func (s *SharedTestSuite) TestUploadIso() {
+	tmp, err := ioutil.TempFile("", "test*.iso")
+	defer os.Remove(tmp.Name())
+	_, err = s.Client.UploadFile(tmp)
+	s.Require().Error(err)
+	s.Require().Equal("File must not have .iso extension", err.Error(), "Should not allow .iso files")
 }


### PR DESCRIPTION
This adds file upload functionality. A lot of this is based on the code in this article:
https://devcentral.f5.com/articles/demystifying-icontrol-rest-part-5-transferring-files

I also tried to mimic some of the logic of the F5 Python SDK as far as how the new methods are organized. 

The major features are the methods `UploadFile` in `shared.go` and `UploadSoftwareImage` in `cm.go`. These methods are virtually identical, except for whether they allow a `.iso` extension. I also added a method, `UploadBytes` in `shared.go` for the sake of convenience, since my use case involves uploading SSL certificates stored in memory to the F5.

I'm fairly new to Go, so any feedback is greatly appreciated.
