### PR TITLE
changed ModifyClientSSLProfile and ModifyClientServerProfile REST methods to PATCH

### DIFF
--- a/ltm.go
+++ b/ltm.go
@@ -1138,7 +1138,7 @@ func (b *BigIP) DeleteServerSSLProfile(name string) error {
 // ModifyServerSSLProfile allows you to change any attribute of a sever-ssl profile.
 // Fields that can be modified are referenced in the VirtualServer struct.
 func (b *BigIP) ModifyServerSSLProfile(name string, config *ServerSSLProfile) error {
-	return b.put(config, uriLtm, uriProfile, uriServerSSL, name)
+	return b.patch(config, uriLtm, uriProfile, uriServerSSL, name)
 }
 
 // ClientSSLProfiles returns a list of client-ssl profiles.
@@ -1189,7 +1189,7 @@ func (b *BigIP) DeleteClientSSLProfile(name string) error {
 // ModifyClientSSLProfile allows you to change any attribute of a client-ssl profile.
 // Fields that can be modified are referenced in the ClientSSLProfile struct.
 func (b *BigIP) ModifyClientSSLProfile(name string, config *ClientSSLProfile) error {
-	return b.put(config, uriLtm, uriProfile, uriClientSSL, name)
+	return b.patch(config, uriLtm, uriProfile, uriClientSSL, name)
 }
 
 // TcpProfiles returns a list of Tcp profiles

--- a/ltm_test.go
+++ b/ltm_test.go
@@ -1336,8 +1336,8 @@ func (s *LTMTestSuite) TestAddInternalDataGroup() {
 
 func (s *LTMTestSuite) TestAddInternalDataGroup_emptyRecords() {
 	config := &DataGroup{
-		Name: "test-datagroup",
-		Type: "string",
+		Name:    "test-datagroup",
+		Type:    "string",
 		Records: []DataGroupRecord{},
 	}
 
@@ -1625,7 +1625,7 @@ func (s *LTMTestSuite) TestModifyServerSSLProfile() {
 
 	s.Client.ModifyServerSSLProfile(serverSSLProfile, myModifedServerSSLProfile)
 
-	assert.Equal(s.T(), "PUT", s.LastRequest.Method)
+	assert.Equal(s.T(), "PATCH", s.LastRequest.Method)
 	assert.Equal(s.T(), fmt.Sprintf("/mgmt/tm/%s/%s/%s/%s", uriLtm, uriProfile, uriServerSSL, serverSSLProfile), s.LastRequest.URL.Path)
 	assert.Equal(s.T(), `{"cert":"/Common/default.crt","key":"/Common/default.key","mode":"enabled","serverName":"myserver.contoso.com"}`, s.LastRequestBody)
 }
@@ -1881,7 +1881,7 @@ func (s *LTMTestSuite) TestModifyClientSSLProfile() {
 
 	s.Client.ModifyClientSSLProfile(clientSSLProfile, myModifedClientSSLProfile)
 
-	assert.Equal(s.T(), "PUT", s.LastRequest.Method)
+	assert.Equal(s.T(), "PATCH", s.LastRequest.Method)
 	assert.Equal(s.T(), fmt.Sprintf("/mgmt/tm/%s/%s/%s/%s", uriLtm, uriProfile, uriClientSSL, clientSSLProfile), s.LastRequest.URL.Path)
 	assert.Equal(s.T(), `{"cert":"/Common/default.crt","key":"/Common/default.key","mode":"enabled","serverName":"myserver.contoso.com"}`, s.LastRequestBody)
 }


### PR DESCRIPTION
Issue:
https://github.com/scottdware/go-bigip/issues/94

Note that I tried to run ltm_test.go, but seemed to encounter some issues on my local with package management.  If you can test this that would be good.