### PR TITLE
Use env defined HTTP proxy

### DIFF
--- a/bigip.go
+++ b/bigip.go
@@ -95,6 +95,7 @@ func NewSession(host, user, passwd string, configOptions *ConfigOptions) *BigIP 
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,
 			},
+			Proxy: http.ProxyFromEnvironment,
 		},
 		ConfigOptions: configOptions,
 	}


### PR DESCRIPTION
Add HTTP proxy from env variable to the session transport options so that connection to BigIP can be done through defined HTTP proxy