### PR TITLE
Implementing save sys config and load sys config

### DIFF
--- a/sys_test.go
+++ b/sys_test.go
@@ -439,3 +439,43 @@ func (s *SysTestSuite) TestDeleteKey() {
 	assert.Equal(s.T(), fmt.Sprintf("/mgmt/tm/%s/%s/%s/%s", uriSys, uriFile, uriSslKey, "~Common~test.key"), s.LastRequest.URL.Path, "Wrong uri to delete key")
 	assert.Equal(s.T(), "DELETE", s.LastRequest.Method)
 }
+
+func (s *SysTestSuite) TestSaveSysConfig() {
+	s.ResponseFunc = func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}
+	err := s.Client.SaveSysConfig("", "")
+	assert.Nil(s.T(), err)
+
+	err = s.Client.SaveSysConfig("backup.scf", "")
+	assert.Nil(s.T(), err)
+
+	err = s.Client.SaveSysConfig("backup.scf", "secret-key")
+	assert.Nil(s.T(), err)
+
+	err = s.Client.SaveSysConfig("backup.tar", "")
+	assert.Nil(s.T(), err)
+
+	err = s.Client.SaveSysConfig("backup.tar", "secret-key")
+	assert.Nil(s.T(), err)
+}
+
+func (s *SysTestSuite) TestLodSysConfig() {
+	s.ResponseFunc = func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}
+	err := s.Client.LoadSysConfig("", "")
+	assert.Nil(s.T(), err)
+
+	err = s.Client.LoadSysConfig("backup.scf", "")
+	assert.Nil(s.T(), err)
+
+	err = s.Client.LoadSysConfig("backup.scf", "secret-key")
+	assert.Nil(s.T(), err)
+
+	err = s.Client.LoadSysConfig("backup.tar", "")
+	assert.Nil(s.T(), err)
+
+	err = s.Client.LoadSysConfig("backup.tar", "secret-key")
+	assert.Nil(s.T(), err)
+}


### PR DESCRIPTION
Implementing support for save current running configuration and load configuration from a file. 

endpoint : POST /mgmt/tm/sys/config
request body : {
"command" : "save" or "load"
"options":  [{"file":<file_name>},{"passphrase":<passphrase-for-encryption>}]
}

options is optional field, when not provided the configuration will be saved to or load from default file. passphrase is used to encrypt the file, when not provided the file will be unencrypted. To load config from an encrypted file, the same passphrase that was used to save the file must be used to load.
To save/lod the config to/from a .tar file, provide the file name ending with .tar; for example "backup.tar"