### PR TITLE
Allow charset in Content-Type

### DIFF
--- a/bigip.go
+++ b/bigip.go
@@ -153,7 +153,7 @@ func (b *BigIP) APICall(options *APIRequest) ([]byte, error) {
 	data, _ := ioutil.ReadAll(res.Body)
 
 	if res.StatusCode >= 400 {
-		if res.Header.Get("Content-Type") == "application/json" {
+		if strings.HasPrefix(res.Header.Get("Content-Type"), "application/json") {
 			return data, b.checkError(data)
 		}
 


### PR DESCRIPTION
Parsing of error message fails if value of the response's Content-Type header is `application/json; charset=utf-8`